### PR TITLE
Listen on [::]:80 in dual-stack mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM k8s.gcr.io/echoserver:1.10
-RUN sed -i 's/listen 8080/listen 80/g' /etc/nginx/nginx.conf
+RUN sed -i 's/listen 8080/listen [::]:80 ipv6only=off/g' /etc/nginx/nginx.conf


### PR DESCRIPTION
Instead of only listening on IPv4-only by default, enable the IPv6
dual-stack mode.

Signed-off-by: Sebastian Wicki <gandro@gmx.net>