### PR TITLE
Set default listening port to 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM k8s.gcr.io/echoserver:1.10
 RUN sed -i 's/listen 8080/listen [::]:PORT ipv6only=off/g' /etc/nginx/nginx.conf
-ENV PORT 8080
+ENV PORT 80
 ENTRYPOINT sed -i "s/PORT/${PORT}/g" /etc/nginx/nginx.conf && /usr/local/bin/run.sh


### PR DESCRIPTION
The v1.10.1 of this image listens on port 80. v1.10.2 makes the port configurable but listens on port 8080 by default. Since most Cilium tests using that image are testing port 80, we should keep that as the default to ease the image update.